### PR TITLE
Improves the Namesilo API wrapper

### DIFF
--- a/cmd/nsdns/update.go
+++ b/cmd/nsdns/update.go
@@ -24,8 +24,14 @@ func updateCommand() *cobra.Command {
 		Use:   "update",
 		Short: "update dns records",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			log.SetLevel(log.DebugLevel)
+
 			if domainName == "" {
 				return fmt.Errorf("Must provide a domain name to update DNS records.")
+			}
+
+			if ingressClass == "" {
+				return fmt.Errorf("Must provide an ingress class to select DNS records.")
 			}
 
 			nsApiKey := os.Getenv("NAMESILO_API_KEY")
@@ -47,7 +53,7 @@ func updateCommand() *cobra.Command {
 				return err
 			}
 
-			ingressRecords, err := GetResourcesFromKubernetesIngresses(domainName, ip)
+			ingressRecords, err := GetResourcesFromKubernetesIngresses(domainName, ip, ingressClass)
 			if err != nil {
 				return err
 			}

--- a/cmd/nsdns/update.go
+++ b/cmd/nsdns/update.go
@@ -114,7 +114,7 @@ func updateARecord(api *namesilo_api.NamesiloApi, record namesilo_api.ResourceRe
 }
 
 func addARecord(api *namesilo_api.NamesiloApi, record namesilo_api.ResourceRecord, domainName, ip string) error {
-	err:= api.AddDNSRecord(domainName, record.Type, "", ip, 7207)
+	err := api.AddDNSRecord(domainName, record.Type, "", ip, 7207)
 	if err != nil {
 		return err
 	}

--- a/cmd/nsdns/update.go
+++ b/cmd/nsdns/update.go
@@ -61,17 +61,8 @@ func updateCommand() *cobra.Command {
 			}
 
 			for _, record := range rr.Add {
-				switch record.Type {
-				case "A":
-					if err := addARecord(api, record, domainName, ip); err != nil {
-						return err
-					}
-				case "CNAME":
-					if err := addCnameRecord(api, record, domainName); err != nil {
-						return err
-					}
-				default:
-					log.Infof("Can't add record of type \"%s\"\n", record.Type)
+				if err := api.AddDNSRecord(record); err != nil {
+					return err
 				}
 			}
 
@@ -113,17 +104,6 @@ func updateARecord(api *namesilo_api.NamesiloApi, record namesilo_api.ResourceRe
 	return nil
 }
 
-func addARecord(api *namesilo_api.NamesiloApi, record namesilo_api.ResourceRecord, domainName, ip string) error {
-	err := api.AddDNSRecord(domainName, record.Type, "", ip, 7207)
-	if err != nil {
-		return err
-	}
-
-	log.Infof("Created %s record %s to %s", record.Type, domainName, ip)
-
-	return nil
-}
-
 func updateCnameRecord(api *namesilo_api.NamesiloApi, record namesilo_api.ResourceRecord, domainName string) error {
 	if record.Value == domainName {
 		log.Infof("Skipping CNAME record %s because it's already set correctly\n", record.Host)
@@ -136,20 +116,6 @@ func updateCnameRecord(api *namesilo_api.NamesiloApi, record namesilo_api.Resour
 
 		log.Infof("Updated %s record %s to %s", record.Type, record.RecordId, domainName)
 	}
-
-	return nil
-}
-
-func addCnameRecord(api *namesilo_api.NamesiloApi, record namesilo_api.ResourceRecord, domainName string) error {
-	domainSuffix := fmt.Sprintf(".%s", domainName)
-	subdomain := strings.TrimSuffix(record.Host, domainSuffix)
-
-	err := api.AddDNSRecord(domainName, record.Type, subdomain, subdomain, 7207)
-	if err != nil {
-		return err
-	}
-
-	log.Infof("Created %s record %s to %s", record.Type, subdomain, domainName)
 
 	return nil
 }

--- a/cmd/nsdns/update.go
+++ b/cmd/nsdns/update.go
@@ -33,9 +33,9 @@ func updateCommand() *cobra.Command {
 				return fmt.Errorf("Failed to find NAMESILO_API_KEY in environment. Cannot proceed.")
 			}
 
-			api := namesilo_api.NewNamesiloApi(nsApiKey)
+			api := namesilo_api.NewNamesiloApi(domainName, nsApiKey)
 
-			records, err := api.ListDNSRecords(domainName)
+			records, err := api.ListDNSRecords()
 			if err != nil {
 				return err
 			}

--- a/cmd/nsdns/update.go
+++ b/cmd/nsdns/update.go
@@ -67,6 +67,7 @@ func updateCommand() *cobra.Command {
 			}
 
 			for _, record := range rr.Add {
+				log.Infof("Adding record for %s", record.Host)
 				if err := api.AddDNSRecord(record); err != nil {
 					return err
 				}

--- a/cmd/nsdns/utils.go
+++ b/cmd/nsdns/utils.go
@@ -24,7 +24,7 @@ type RecordReconciliation struct {
 	NoOp   []namesilo_api.ResourceRecord
 }
 
-func GetResourcesFromKubernetesIngresses(domainName, ip string) ([]namesilo_api.ResourceRecord, error) {
+func GetResourcesFromKubernetesIngresses(domainName, ip, ingressClass string) ([]namesilo_api.ResourceRecord, error) {
 	rv := []namesilo_api.ResourceRecord{}
 
 	home := homedir.HomeDir()
@@ -46,7 +46,7 @@ func GetResourcesFromKubernetesIngresses(domainName, ip string) ([]namesilo_api.
 	}
 
 	for _, item := range items.Items {
-		if ingressClass, _ := item.Annotations["kubernetes.io/ingress.class"]; ingressClass != "nginx-external" {
+		if thisIngressClass, _ := item.Annotations["kubernetes.io/ingress.class"]; thisIngressClass != ingressClass {
 			log.Tracef("Skipping ingress %s because it has incorrect ingress class", item.ObjectMeta.Name)
 			continue
 		}

--- a/cmd/nsdns/utils.go
+++ b/cmd/nsdns/utils.go
@@ -72,7 +72,7 @@ func ReconcileRecords(existing, new []namesilo_api.ResourceRecord) RecordReconci
 
 	for _, res := range new {
 		if r, ok := existingByHost[res.Host]; ok {
-			if RecordRequiresReconciliation(r, res) {
+			if RecordsEqual(r, res) {
 				rr.NoOp = append(rr.NoOp, res)
 			} else {
 				rr.Update = append(rr.Update, res)
@@ -85,7 +85,7 @@ func ReconcileRecords(existing, new []namesilo_api.ResourceRecord) RecordReconci
 	return rr
 }
 
-func RecordRequiresReconciliation(existing, new namesilo_api.ResourceRecord) bool {
+func RecordsEqual(existing, new namesilo_api.ResourceRecord) bool {
 	return existing.Type == new.Type &&
 		existing.Host == new.Host &&
 		existing.Value == new.Value &&

--- a/pkg/namesilo_api/api.go
+++ b/pkg/namesilo_api/api.go
@@ -10,7 +10,7 @@ import (
 const DefaultApiURLPrefix string = "https://www.namesilo.com/api/"
 
 type NamesiloApi struct {
-	apiKey string
+	apiKey    string
 	apiPrefix string
 }
 
@@ -44,14 +44,14 @@ type DNSUpdateRecordsResponse DNSAddRecordsResponse
 
 func NewNamesiloApi(apiKey string) *NamesiloApi {
 	return &NamesiloApi{
-		apiKey: apiKey,
+		apiKey:    apiKey,
 		apiPrefix: DefaultApiURLPrefix,
 	}
 }
 
 func NewNamesiloApiWithServer(apiKey, apiPrefix string) *NamesiloApi {
 	return &NamesiloApi{
-		apiKey: apiKey,
+		apiKey:    apiKey,
 		apiPrefix: apiPrefix,
 	}
 }

--- a/pkg/namesilo_api/api.go
+++ b/pkg/namesilo_api/api.go
@@ -29,6 +29,7 @@ type ListDNSRecordsResponse struct {
 	Reply   struct {
 		XMLName         xml.Name         `xml:"reply"`
 		ResourceRecords []ResourceRecord `xml:"resource_record"`
+		Detail          string           `xml:"detail"`
 	}
 }
 
@@ -73,7 +74,11 @@ func (ns *NamesiloApi) ListDNSRecords(domain string) ([]ResourceRecord, error) {
 		return nil, err
 	}
 
-	return ldrr.Reply.ResourceRecords, nil
+	if ldrr.Reply.Detail == "success" {
+		return ldrr.Reply.ResourceRecords, nil
+	}
+
+	return nil, fmt.Errorf("namesilo domain list failed with: %s", ldrr.Reply.Detail)
 }
 
 func (ns *NamesiloApi) UpdateDNSRecord(domain, host, id, value string, ttl int) error {

--- a/pkg/namesilo_api/api.go
+++ b/pkg/namesilo_api/api.go
@@ -14,6 +14,7 @@ const DefaultApiURLPrefix string = "https://www.namesilo.com/api/"
 type NamesiloApi struct {
 	apiKey    string
 	apiPrefix string
+	domain    string
 }
 
 type ResourceRecord struct {
@@ -45,25 +46,24 @@ type DNSAddRecordsResponse struct {
 
 type DNSUpdateRecordsResponse DNSAddRecordsResponse
 
-func NewNamesiloApi(apiKey string) *NamesiloApi {
+func NewNamesiloApi(domain, apiKey string) *NamesiloApi {
 	return &NamesiloApi{
 		apiKey:    apiKey,
 		apiPrefix: DefaultApiURLPrefix,
+		domain:    domain,
 	}
 }
 
-func NewNamesiloApiWithServer(apiKey, apiPrefix string) *NamesiloApi {
+func NewNamesiloApiWithServer(domain, apiKey, apiPrefix string) *NamesiloApi {
 	return &NamesiloApi{
 		apiKey:    apiKey,
 		apiPrefix: apiPrefix,
+		domain:    domain,
 	}
 }
 
-func (ns *NamesiloApi) ListDNSRecords(domain string) ([]ResourceRecord, error) {
+func (ns *NamesiloApi) ListDNSRecords() ([]ResourceRecord, error) {
 	reqValues := url.Values{}
-
-	reqValues.Add("domain", domain)
-
 	reqUrl, err := ns.apiActionWithValues("dnsListRecords", &reqValues)
 	if err != nil {
 		return nil, err
@@ -82,7 +82,6 @@ func (ns *NamesiloApi) ListDNSRecords(domain string) ([]ResourceRecord, error) {
 func (ns *NamesiloApi) UpdateDNSRecord(domain, host, id, value string, ttl int) error {
 	reqValues := url.Values{}
 
-	reqValues.Add("domain", domain)
 	reqValues.Add("rrid", id)
 	reqValues.Add("rrhost", host)
 	reqValues.Add("rrvalue", value)
@@ -106,7 +105,6 @@ func (ns *NamesiloApi) UpdateDNSRecord(domain, host, id, value string, ttl int) 
 func (ns *NamesiloApi) AddDNSRecord(domain, domainType, host, value string, ttl int) error {
 	reqValues := url.Values{}
 
-	reqValues.Add("domain", domain)
 	reqValues.Add("rrtype", domainType)
 	reqValues.Add("rrhost", host)
 	reqValues.Add("rrvalue", domain)
@@ -139,6 +137,7 @@ func (ns *NamesiloApi) apiActionWithValues(action string, values *url.Values) (*
 	newValues.Add("version", "1")
 	newValues.Add("type", "xml")
 	newValues.Add("key", ns.apiKey)
+	newValues.Add("domain", ns.domain)
 
 	reqUrl.RawQuery = newValues.Encode()
 

--- a/pkg/namesilo_api/api.go
+++ b/pkg/namesilo_api/api.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
+	"strconv"
 )
 
 const DefaultApiURLPrefix string = "https://www.namesilo.com/api/"
@@ -58,8 +60,20 @@ func NewNamesiloApiWithServer(apiKey, apiPrefix string) *NamesiloApi {
 }
 
 func (ns *NamesiloApi) ListDNSRecords(domain string) ([]ResourceRecord, error) {
-	url := fmt.Sprintf("%s/%s?version=1&type=xml&key=%s&domain=%s", ns.apiPrefix, "dnsListRecords", ns.apiKey, domain)
-	response, err := http.Get(url)
+	reqUrl, err := url.Parse(fmt.Sprintf("%s/%s", ns.apiPrefix, "dnsListRecords"))
+	if err != nil {
+		return nil, err
+	}
+
+	reqQuery := reqUrl.Query()
+	reqQuery.Add("version", "1")
+	reqQuery.Add("type", "xml")
+	reqQuery.Add("key", ns.apiKey)
+	reqQuery.Add("domain", domain)
+
+	reqUrl.RawQuery = reqQuery.Encode()
+
+	response, err := http.Get(reqUrl.String())
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +96,24 @@ func (ns *NamesiloApi) ListDNSRecords(domain string) ([]ResourceRecord, error) {
 }
 
 func (ns *NamesiloApi) UpdateDNSRecord(domain, host, id, value string, ttl int) error {
-	url := fmt.Sprintf("%s/%s?version=1&type=xml&key=%s&domain=%s&rrid=%s&rrhost=%s&rrvalue=%s&rrttl=%d", ns.apiPrefix, "dnsUpdateRecord", ns.apiKey, domain, id, host, value, ttl)
-	response, err := http.Get(url)
+	reqUrl, err := url.Parse(fmt.Sprintf("%s/%s", ns.apiPrefix, "dnsUpdateRecord"))
+	if err != nil {
+		return err
+	}
+
+	reqQuery := reqUrl.Query()
+	reqQuery.Add("version", "1")
+	reqQuery.Add("type", "xml")
+	reqQuery.Add("key", ns.apiKey)
+	reqQuery.Add("domain", domain)
+	reqQuery.Add("rrid", id)
+	reqQuery.Add("rrhost", host)
+	reqQuery.Add("rrvalue", value)
+	reqQuery.Add("rrttl", strconv.Itoa(ttl))
+
+	reqUrl.RawQuery = reqQuery.Encode()
+
+	response, err := http.Get(reqUrl.String())
 	if err != nil {
 		return err
 	}
@@ -106,8 +136,25 @@ func (ns *NamesiloApi) UpdateDNSRecord(domain, host, id, value string, ttl int) 
 }
 
 func (ns *NamesiloApi) AddDNSRecord(domain, domainType, host, value string, ttl int) error {
-	url := fmt.Sprintf("%s/%s?version=1&type=xml&key=%s&domain=%s&rrtype=%s&rrhost=%s&rrvalue=%s&rrttl=%d&rrdistance=0", ns.apiPrefix, "dnsAddRecord", ns.apiKey, domain, domainType, host, domain, ttl)
-	response, err := http.Get(url)
+	reqUrl, err := url.Parse(fmt.Sprintf("%s/%s", ns.apiPrefix, "dnsAddRecord"))
+	if err != nil {
+		return err
+	}
+
+	reqQuery := reqUrl.Query()
+	reqQuery.Add("version", "1")
+	reqQuery.Add("type", "xml")
+	reqQuery.Add("key", ns.apiKey)
+	reqQuery.Add("domain", domain)
+	reqQuery.Add("rrtype", domainType)
+	reqQuery.Add("rrhost", host)
+	reqQuery.Add("rrvalue", domain)
+	reqQuery.Add("rrttl", strconv.Itoa(ttl))
+	reqQuery.Add("rrdistance", "0")
+
+	reqUrl.RawQuery = reqQuery.Encode()
+
+	response, err := http.Get(reqUrl.String())
 	if err != nil {
 		return err
 	}

--- a/pkg/namesilo_api/api.go
+++ b/pkg/namesilo_api/api.go
@@ -7,10 +7,11 @@ import (
 	"net/http"
 )
 
-const NamesiloApiURLPrefix string = "https://www.namesilo.com/api/"
+const DefaultApiURLPrefix string = "https://www.namesilo.com/api/"
 
 type NamesiloApi struct {
 	apiKey string
+	apiPrefix string
 }
 
 type ResourceRecord struct {
@@ -44,11 +45,19 @@ type DNSUpdateRecordsResponse DNSAddRecordsResponse
 func NewNamesiloApi(apiKey string) *NamesiloApi {
 	return &NamesiloApi{
 		apiKey: apiKey,
+		apiPrefix: DefaultApiURLPrefix,
+	}
+}
+
+func NewNamesiloApiWithServer(apiKey, apiPrefix string) *NamesiloApi {
+	return &NamesiloApi{
+		apiKey: apiKey,
+		apiPrefix: apiPrefix,
 	}
 }
 
 func (ns *NamesiloApi) ListDNSRecords(domain string) ([]ResourceRecord, error) {
-	url := fmt.Sprintf("%s/%s?version=1&type=xml&key=%s&domain=%s", NamesiloApiURLPrefix, "dnsListRecords", ns.apiKey, domain)
+	url := fmt.Sprintf("%s/%s?version=1&type=xml&key=%s&domain=%s", ns.apiPrefix, "dnsListRecords", ns.apiKey, domain)
 	response, err := http.Get(url)
 	if err != nil {
 		return nil, err
@@ -68,7 +77,7 @@ func (ns *NamesiloApi) ListDNSRecords(domain string) ([]ResourceRecord, error) {
 }
 
 func (ns *NamesiloApi) UpdateDNSRecord(domain, host, id, value string, ttl int) error {
-	url := fmt.Sprintf("%s/%s?version=1&type=xml&key=%s&domain=%s&rrid=%s&rrhost=%s&rrvalue=%s&rrttl=%d", NamesiloApiURLPrefix, "dnsUpdateRecord", ns.apiKey, domain, id, host, value, ttl)
+	url := fmt.Sprintf("%s/%s?version=1&type=xml&key=%s&domain=%s&rrid=%s&rrhost=%s&rrvalue=%s&rrttl=%d", ns.apiPrefix, "dnsUpdateRecord", ns.apiKey, domain, id, host, value, ttl)
 	response, err := http.Get(url)
 	if err != nil {
 		return err
@@ -92,7 +101,7 @@ func (ns *NamesiloApi) UpdateDNSRecord(domain, host, id, value string, ttl int) 
 }
 
 func (ns *NamesiloApi) AddDNSRecord(domain, domainType, host, value string, ttl int) error {
-	url := fmt.Sprintf("%s/%s?version=1&type=xml&key=%s&domain=%s&rrtype=%s&rrhost=%s&rrvalue=%s&rrttl=%d&rrdistance=0", NamesiloApiURLPrefix, "dnsAddRecord", ns.apiKey, domain, domainType, host, domain, ttl)
+	url := fmt.Sprintf("%s/%s?version=1&type=xml&key=%s&domain=%s&rrtype=%s&rrhost=%s&rrvalue=%s&rrttl=%d&rrdistance=0", ns.apiPrefix, "dnsAddRecord", ns.apiKey, domain, domainType, host, domain, ttl)
 	response, err := http.Get(url)
 	if err != nil {
 		return err

--- a/pkg/namesilo_api/api_test.go
+++ b/pkg/namesilo_api/api_test.go
@@ -2,8 +2,6 @@ package namesilo_api
 
 import (
 	"encoding/xml"
-	// "fmt"
-	// "io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,7 +11,39 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestListDNSRecords(t *testing.T) {
+func TestListDNSRecord(t *testing.T) {
+	expectedCalls := 1
+	calls := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/dnsListRecords", r.URL.Path)
+
+		q := r.URL.Query()
+		assert.Equal(t, []string{"1"}, q["version"])
+		assert.Equal(t, []string{"xml"}, q["type"])
+		assert.Equal(t, []string{"api-key"}, q["key"])
+		assert.Equal(t, []string{"example.com"}, q["domain"])
+
+		var response ListDNSRecordsResponse
+		response.Reply.ResourceRecords = append(response.Reply.ResourceRecords, ResourceRecord{})
+		body, err := xml.Marshal(response)
+		assert.NoError(t, err)
+		w.Write(body)
+
+		calls += 1
+	}))
+	defer server.Close()
+
+	api := NewNamesiloApiWithServer("api-key", server.URL)
+	rr, err := api.ListDNSRecords("example.com")
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedCalls, calls)
+
+	assert.Equal(t, 1, len(rr))
+}
+
+func TestUpdateDNSRecord(t *testing.T) {
 	expectedCalls := 1
 	calls := 0
 
@@ -42,6 +72,41 @@ func TestListDNSRecords(t *testing.T) {
 
 	api := NewNamesiloApiWithServer("api-key", server.URL)
 	err := api.UpdateDNSRecord("example.com", "sub", "abc123", "192.168.1.1", 1234)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedCalls, calls)
+}
+
+func TestAddDNSRecord(t *testing.T) {
+	expectedCalls := 1
+	calls := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/dnsAddRecord", r.URL.Path)
+
+		q := r.URL.Query()
+		assert.Equal(t, []string{"1"}, q["version"])
+		assert.Equal(t, []string{"xml"}, q["type"])
+		assert.Equal(t, []string{"api-key"}, q["key"])
+		assert.Equal(t, []string{"example.com"}, q["domain"])
+		assert.Equal(t, []string{"sub"}, q["rrhost"])
+		assert.Equal(t, []string{"A"}, q["rrtype"])
+		assert.Equal(t, []string{"example.com"}, q["rrvalue"])
+		assert.Equal(t, []string{"1234"}, q["rrttl"])
+		assert.Equal(t, []string{"0"}, q["rrdistance"])
+
+		var response DNSUpdateRecordsResponse
+		response.Reply.Detail = "success"
+		body, err := xml.Marshal(response)
+		assert.NoError(t, err)
+		w.Write(body)
+
+		calls += 1
+	}))
+	defer server.Close()
+
+	api := NewNamesiloApiWithServer("api-key", server.URL)
+	err := api.AddDNSRecord("example.com", "A", "sub", "192.168.1.1", 1234)
 	assert.NoError(t, err)
 
 	assert.Equal(t, expectedCalls, calls)

--- a/pkg/namesilo_api/api_test.go
+++ b/pkg/namesilo_api/api_test.go
@@ -35,8 +35,8 @@ func TestListDNSRecord(t *testing.T) {
 	}))
 	defer server.Close()
 
-	api := NewNamesiloApiWithServer("api-key", server.URL)
-	rr, err := api.ListDNSRecords("example.com")
+	api := NewNamesiloApiWithServer("example.com", "api-key", server.URL)
+	rr, err := api.ListDNSRecords()
 	assert.NoError(t, err)
 
 	assert.Equal(t, expectedCalls, calls)
@@ -71,8 +71,8 @@ func TestUpdateDNSRecord(t *testing.T) {
 	}))
 	defer server.Close()
 
-	api := NewNamesiloApiWithServer("api-key", server.URL)
-	err := api.UpdateDNSRecord("example.com", "sub", "abc123", "192.168.1.1", 1234)
+	api := NewNamesiloApiWithServer("example.com", "api-key", server.URL)
+	err := api.UpdateDNSRecord("sub", "abc123", "192.168.1.1", 1234)
 	assert.NoError(t, err)
 
 	assert.Equal(t, expectedCalls, calls)
@@ -106,8 +106,8 @@ func TestAddDNSRecord(t *testing.T) {
 	}))
 	defer server.Close()
 
-	api := NewNamesiloApiWithServer("api-key", server.URL)
-	err := api.AddDNSRecord("example.com", "A", "sub", "192.168.1.1", 1234)
+	api := NewNamesiloApiWithServer("example.com", "api-key", server.URL)
+	err := api.AddDNSRecord("A", "sub", "192.168.1.1", 1234)
 	assert.NoError(t, err)
 
 	assert.Equal(t, expectedCalls, calls)

--- a/pkg/namesilo_api/api_test.go
+++ b/pkg/namesilo_api/api_test.go
@@ -44,7 +44,7 @@ func TestListDNSRecord(t *testing.T) {
 	assert.Equal(t, 1, len(rr))
 }
 
-func TestUpdateDNSRecord(t *testing.T) {
+func TestUpdateDNSARecord(t *testing.T) {
 	expectedCalls := 1
 	calls := 0
 
@@ -71,9 +71,86 @@ func TestUpdateDNSRecord(t *testing.T) {
 	}))
 	defer server.Close()
 
+	record := ResourceRecord{
+		RecordId: "abc123",
+		Type: "A",
+		Host: "sub.example.com",
+		Value: "192.168.1.1",
+		TTL: 1234,
+		Distance :0,
+	}
+
 	api := NewNamesiloApiWithServer("example.com", "api-key", server.URL)
-	err := api.UpdateDNSRecord("example.com", "sub", "abc123", "192.168.1.1", 1234)
+	err := api.UpdateDNSRecord(record)
 	assert.NoError(t, err)
+
+	assert.Equal(t, expectedCalls, calls)
+}
+
+
+func TestUpdateDNSCnameRecord(t *testing.T) {
+	expectedCalls := 1
+	calls := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/dnsUpdateRecord", r.URL.Path)
+
+		q := r.URL.Query()
+		assert.Equal(t, []string{"1"}, q["version"])
+		assert.Equal(t, []string{"xml"}, q["type"])
+		assert.Equal(t, []string{"api-key"}, q["key"])
+		assert.Equal(t, []string{"example.com"}, q["domain"])
+		assert.Equal(t, []string{"abc123"}, q["rrid"])
+		assert.Equal(t, []string{"sub"}, q["rrhost"])
+		assert.Equal(t, []string{"example.com"}, q["rrvalue"])
+		assert.Equal(t, []string{"1234"}, q["rrttl"])
+
+		var response DNSUpdateRecordsResponse
+		response.Reply.Detail = "success"
+		body, err := xml.Marshal(response)
+		assert.NoError(t, err)
+		w.Write(body)
+
+		calls += 1
+	}))
+	defer server.Close()
+
+	record := ResourceRecord{
+		RecordId: "abc123",
+		Type: "CNAME",
+		Host: "sub.example.com",
+		Value: "example.com",
+		TTL: 1234,
+		Distance :0,
+	}
+
+	api := NewNamesiloApiWithServer("example.com", "api-key", server.URL)
+	err := api.UpdateDNSRecord(record)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedCalls, calls)
+}
+
+func TestUpdateDNSRecordFailsWithNoRRID(t *testing.T) {
+	expectedCalls := 0
+	calls := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls += 1
+	}))
+	defer server.Close()
+
+	record := ResourceRecord{
+		Type: "CNAME",
+		Host: "sub.example.com",
+		Value: "example.com",
+		TTL: 1234,
+		Distance :0,
+	}
+
+	api := NewNamesiloApiWithServer("example.com", "api-key", server.URL)
+	err := api.UpdateDNSRecord(record)
+	assert.Equal(t, err.Error(), "cannot update DNS record without record id")
 
 	assert.Equal(t, expectedCalls, calls)
 }
@@ -120,6 +197,9 @@ func TestAddDNSRecordARecord(t *testing.T) {
 
 	assert.Equal(t, expectedCalls, calls)
 }
+
+
+
 
 func TestAddDNSRecordCnameRecord(t *testing.T) {
 	expectedCalls := 1

--- a/pkg/namesilo_api/api_test.go
+++ b/pkg/namesilo_api/api_test.go
@@ -26,6 +26,7 @@ func TestListDNSRecord(t *testing.T) {
 
 		var response ListDNSRecordsResponse
 		response.Reply.ResourceRecords = append(response.Reply.ResourceRecords, ResourceRecord{})
+		response.Reply.Detail = "success"
 		body, err := xml.Marshal(response)
 		assert.NoError(t, err)
 		w.Write(body)

--- a/pkg/namesilo_api/api_test.go
+++ b/pkg/namesilo_api/api_test.go
@@ -72,13 +72,56 @@ func TestUpdateDNSRecord(t *testing.T) {
 	defer server.Close()
 
 	api := NewNamesiloApiWithServer("example.com", "api-key", server.URL)
-	err := api.UpdateDNSRecord("sub", "abc123", "192.168.1.1", 1234)
+	err := api.UpdateDNSRecord("example.com", "sub", "abc123", "192.168.1.1", 1234)
 	assert.NoError(t, err)
 
 	assert.Equal(t, expectedCalls, calls)
 }
 
-func TestAddDNSRecord(t *testing.T) {
+func TestAddDNSRecordARecord(t *testing.T) {
+	expectedCalls := 1
+	calls := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/dnsAddRecord", r.URL.Path)
+
+		q := r.URL.Query()
+		assert.Equal(t, []string{"1"}, q["version"])
+		assert.Equal(t, []string{"xml"}, q["type"])
+		assert.Equal(t, []string{"api-key"}, q["key"])
+		assert.Equal(t, []string{"example.com"}, q["domain"])
+		assert.Equal(t, []string{""}, q["rrhost"])
+		assert.Equal(t, []string{"A"}, q["rrtype"])
+		assert.Equal(t, []string{"192.168.1.1"}, q["rrvalue"])
+		assert.Equal(t, []string{"1234"}, q["rrttl"])
+		assert.Equal(t, []string{"0"}, q["rrdistance"])
+
+		var response DNSUpdateRecordsResponse
+		response.Reply.Detail = "success"
+		body, err := xml.Marshal(response)
+		assert.NoError(t, err)
+		w.Write(body)
+
+		calls += 1
+	}))
+	defer server.Close()
+
+	record := ResourceRecord{
+		Type: "A",
+		Host: "example.com",
+		Value: "192.168.1.1",
+		TTL: 1234,
+		Distance :0,
+	}
+
+	api := NewNamesiloApiWithServer("example.com", "api-key", server.URL)
+	err := api.AddDNSRecord(record)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedCalls, calls)
+}
+
+func TestAddDNSRecordCnameRecord(t *testing.T) {
 	expectedCalls := 1
 	calls := 0
 
@@ -91,7 +134,7 @@ func TestAddDNSRecord(t *testing.T) {
 		assert.Equal(t, []string{"api-key"}, q["key"])
 		assert.Equal(t, []string{"example.com"}, q["domain"])
 		assert.Equal(t, []string{"sub"}, q["rrhost"])
-		assert.Equal(t, []string{"A"}, q["rrtype"])
+		assert.Equal(t, []string{"CNAME"}, q["rrtype"])
 		assert.Equal(t, []string{"example.com"}, q["rrvalue"])
 		assert.Equal(t, []string{"1234"}, q["rrttl"])
 		assert.Equal(t, []string{"0"}, q["rrdistance"])
@@ -106,8 +149,16 @@ func TestAddDNSRecord(t *testing.T) {
 	}))
 	defer server.Close()
 
+	record := ResourceRecord{
+		Type: "CNAME",
+		Host: "sub.example.com",
+		Value: "example.com",
+		TTL: 1234,
+		Distance :0,
+	}
+
 	api := NewNamesiloApiWithServer("example.com", "api-key", server.URL)
-	err := api.AddDNSRecord("A", "sub", "192.168.1.1", 1234)
+	err := api.AddDNSRecord(record)
 	assert.NoError(t, err)
 
 	assert.Equal(t, expectedCalls, calls)


### PR DESCRIPTION
Updates the Namesilo API wrapper to accept a `ResourceRecord` as its argument, rather than a smattering of parameters.