### PR TITLE
Adds in an api wrapper to delete DNS records

### DIFF
--- a/pkg/namesilo_api/api.go
+++ b/pkg/namesilo_api/api.go
@@ -47,6 +47,7 @@ type DNSAddRecordsResponse struct {
 }
 
 type DNSUpdateRecordsResponse DNSAddRecordsResponse
+type DNSDeleteRecordsResponse DNSAddRecordsResponse
 
 func NewNamesiloApi(domain, apiKey string) *NamesiloApi {
 	return NewNamesiloApiWithServer(domain, apiKey, DefaultApiURLPrefix)
@@ -141,6 +142,30 @@ func (ns *NamesiloApi) AddDNSRecord(rr ResourceRecord) error {
 		return err
 	} else if darr.Reply.Detail != "success" {
 		return fmt.Errorf("namesilo domain add failed with: %s", darr.Reply.Detail)
+	}
+
+	return nil
+}
+
+func (ns *NamesiloApi) DeleteDNSRecord(rr ResourceRecord) error {
+	if rr.RecordId == "" {
+		return errors.New("cannot delete DNS record without ID")
+	}
+
+	reqValues := url.Values{}
+
+	reqValues.Add("rrid", rr.RecordId)
+
+	reqUrl, err := ns.apiActionWithValues("dnsDeleteRecord", &reqValues)
+	if err != nil {
+		return err
+	}
+
+	var darr DNSDeleteRecordsResponse
+	if err := request(reqUrl, &darr); err != nil {
+		return err
+	} else if darr.Reply.Detail != "success" {
+		return fmt.Errorf("namesilo domain delete failed with: %s", darr.Reply.Detail)
 	}
 
 	return nil

--- a/pkg/namesilo_api/api.go
+++ b/pkg/namesilo_api/api.go
@@ -161,11 +161,11 @@ func (ns *NamesiloApi) DeleteDNSRecord(rr ResourceRecord) error {
 		return err
 	}
 
-	var darr DNSDeleteRecordsResponse
-	if err := request(reqUrl, &darr); err != nil {
+	var ddrr DNSDeleteRecordsResponse
+	if err := request(reqUrl, &ddrr); err != nil {
 		return err
-	} else if darr.Reply.Detail != "success" {
-		return fmt.Errorf("namesilo domain delete failed with: %s", darr.Reply.Detail)
+	} else if ddrr.Reply.Detail != "success" {
+		return fmt.Errorf("namesilo domain delete failed with: %s", ddrr.Reply.Detail)
 	}
 
 	return nil

--- a/pkg/namesilo_api/api_test.go
+++ b/pkg/namesilo_api/api_test.go
@@ -287,7 +287,6 @@ func TestDeleteDNSRecordFailsWithoutId(t *testing.T) {
 	calls := 0
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/dnsDeleteRecord", r.URL.Path)
 		calls += 1
 	}))
 	defer server.Close()

--- a/pkg/namesilo_api/api_test.go
+++ b/pkg/namesilo_api/api_test.go
@@ -198,9 +198,6 @@ func TestAddDNSRecordARecord(t *testing.T) {
 	assert.Equal(t, expectedCalls, calls)
 }
 
-
-
-
 func TestAddDNSRecordCnameRecord(t *testing.T) {
 	expectedCalls := 1
 	calls := 0
@@ -240,6 +237,72 @@ func TestAddDNSRecordCnameRecord(t *testing.T) {
 	api := NewNamesiloApiWithServer("example.com", "api-key", server.URL)
 	err := api.AddDNSRecord(record)
 	assert.NoError(t, err)
+
+	assert.Equal(t, expectedCalls, calls)
+}
+
+func TestDeleteDNSRecord(t *testing.T) {
+	expectedCalls := 1
+	calls := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/dnsDeleteRecord", r.URL.Path)
+
+		q := r.URL.Query()
+		assert.Equal(t, []string{"1"}, q["version"])
+		assert.Equal(t, []string{"xml"}, q["type"])
+		assert.Equal(t, []string{"api-key"}, q["key"])
+		assert.Equal(t, []string{"example.com"}, q["domain"])
+		assert.Equal(t, []string{"abc123"}, q["rrid"])
+
+		var response DNSUpdateRecordsResponse
+		response.Reply.Detail = "success"
+		body, err := xml.Marshal(response)
+		assert.NoError(t, err)
+		w.Write(body)
+
+		calls += 1
+	}))
+	defer server.Close()
+
+	record := ResourceRecord{
+		RecordId: "abc123",
+		Type: "CNAME",
+		Host: "sub.example.com",
+		Value: "example.com",
+		TTL: 1234,
+		Distance :0,
+	}
+
+	api := NewNamesiloApiWithServer("example.com", "api-key", server.URL)
+	err := api.DeleteDNSRecord(record)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedCalls, calls)
+}
+
+
+func TestDeleteDNSRecordFailsWithoutId(t *testing.T) {
+	expectedCalls := 0
+	calls := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/dnsDeleteRecord", r.URL.Path)
+		calls += 1
+	}))
+	defer server.Close()
+
+	record := ResourceRecord{
+		Type: "CNAME",
+		Host: "sub.example.com",
+		Value: "example.com",
+		TTL: 1234,
+		Distance :0,
+	}
+
+	api := NewNamesiloApiWithServer("example.com", "api-key", server.URL)
+	err := api.DeleteDNSRecord(record)
+	assert.Equal(t, err.Error(), "cannot delete DNS record without ID")
 
 	assert.Equal(t, expectedCalls, calls)
 }


### PR DESCRIPTION
It's starting to look like I should have a more condensed set of methods for these. 

Maybe something that combines `apiActionWithValues` + `request`?

Maybe for the next API I need to implement, if there is one.