### PR TITLE
Stay alive when Namesilo is having issues

### DIFF
--- a/cmd/nsdns/utils.go
+++ b/cmd/nsdns/utils.go
@@ -13,12 +13,12 @@ import (
 	apinetworkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/tools/cache"
 )
 
 import (

--- a/cmd/nsdns/utils.go
+++ b/cmd/nsdns/utils.go
@@ -21,6 +21,10 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+import (
+	"github.com/Eagerod/kube-namesilo-dns/pkg/nsdns"
+)
+
 func GetIngresses(namespace string) ([]apinetworkingv1.Ingress, error) {
 	rv := []apinetworkingv1.Ingress{}
 

--- a/cmd/nsdns/watch.go
+++ b/cmd/nsdns/watch.go
@@ -41,16 +41,12 @@ func watchCommand() *cobra.Command {
 				return err
 			}
 
-			// Before starting the informer, start up a loop to update caches
-			// safely.
-			done := make(chan struct{})
-			go func() {
-				for err := dm.UpdateCache(); err != nil; {
-					log.Error("Initial cache update failed. Retrying in 5 minutes...")
-					time.Sleep(5 * time.Minute)
-				}
-				done <- struct{}{}
+			for err := dm.UpdateCache(); err != nil; {
+				log.Error("Initial cache update failed. Retrying in 5 minutes...")
+				time.Sleep(5 * time.Minute)
+			}
 
+			go func() {
 				log.Info("Initial cache update complete. Moving to hourly updates...")
 				for {
 					time.Sleep(1 * time.Hour)
@@ -88,8 +84,6 @@ func watchCommand() *cobra.Command {
 					},
 				},
 			)
-
-			<-done
 
 			stop := make(chan struct{})
 			informerFactory.Start(stop)

--- a/cmd/nsdns/watch.go
+++ b/cmd/nsdns/watch.go
@@ -42,7 +42,7 @@ func watchCommand() *cobra.Command {
 			}
 
 			for err := dm.UpdateCache(); err != nil; {
-				log.Error("Initial cache update failed. Retrying in 5 minutes...")
+				log.Errorf("Initial cache update failed with %s. Retrying in 5 minutes...", err.Error())
 				time.Sleep(5 * time.Minute)
 			}
 
@@ -51,7 +51,7 @@ func watchCommand() *cobra.Command {
 				for {
 					time.Sleep(1 * time.Hour)
 					for err := dm.UpdateCache(); err != nil; {
-						log.Error("Hourly cache update failed. Retrying in 5 minutes...")
+						log.Errorf("Hourly cache update failed with %s. Retrying in 5 minutes...", err.Error())
 						time.Sleep(5 * time.Minute)
 					}
 				}


### PR DESCRIPTION
Right now, when Namesilo returns errors, or they claim that the central .com registry is unavailable, whatever -- The app just dies. 

This leads to the container restarting, trying to fill up its local cache, and then that one just dies, leading to crash looping until Namesilo decides to respond, at which point, everything just comes back up. Seems silly to rely on container restarts for this.

This changes the update loop to allow for failures, waiting 5 minutes to update whenever a failure occurs. 